### PR TITLE
Refine profile README: focused stack, stats, featured work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Senior Manager, DevOps & Engineering Leadership · Atlanta
 I lead DevOps and QA automation teams, architect cloud + platform
 infrastructure, and build AI-leveraged developer experience.
 
-![GitHub stats](https://github-readme-stats-sigma-five.vercel.app/api?username=kevnm67&count_private=true&theme=tokyonight&hide_border=true&show_icons=true)
+![GitHub stats](https://gh-readme-stats-iota-navy.vercel.app/api?username=kevnm67&count_private=true&include_all_commits=true&theme=tokyonight&hide_border=true&show_icons=true)
 
 ## What I do
 

--- a/README.md
+++ b/README.md
@@ -1,108 +1,63 @@
 # Hey, I'm Kevin 👋
 
-Senior DevOps Engineering Manager from Atlanta.
-I build tools that make teams ship faster.
+Senior Manager, DevOps & Engineering Leadership · Atlanta
 
-|  |  |
-| :--: | :--: |
-| ![GitHub stats](https://github-readme-stats-sigma-five.vercel.app/api?username=kevnm67&count_private=true&theme=tokyonight&hide_border=true&show_icons=true) | ![Top languages](https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=kevnm67&theme=tokyonight&hide_border=true&layout=compact&langs_count=8) |
+I lead DevOps and QA automation teams, architect cloud + platform
+infrastructure, and build AI-leveraged developer experience.
+
+![GitHub stats](https://github-readme-stats-sigma-five.vercel.app/api?username=kevnm67&count_private=true&theme=tokyonight&hide_border=true&show_icons=true)
 
 ## What I do
 
-- 📱 **iOS & macOS apps** — Swift 6, SwiftUI, XcodeGen, CI/CD
-- 🔧 **DevOps tooling** — CircleCI orbs, Fastlane, deployment pipelines
-- 🌐 **Network infrastructure** — UniFi, VLAN design, security hardening
-- 🤖 **Developer productivity** — AI-assisted workflows, automation
+- 👥 **Lead DevOps & QA automation** — scaling the teams, pipelines, and
+    release processes behind reliable shipping
+- 🏗️ **Architecture & consulting** — infrastructure, platform, and systems
+    design across AWS and Azure
+- 🤖 **AI-leveraged developer experience** — Claude and Claude Code woven
+    into CI, review, and automation
+- 🧩 **Atlassian platform** — Jira / Atlassian admin and Forge app
+    development
 
-## Core stack
+## Stack
 
+**Cloud & infrastructure**
+
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat&logo=amazonaws&logoColor=white)
+![Azure](https://img.shields.io/badge/Azure-0078D4?style=flat&logo=microsoftazure&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=flat&logo=terraform&logoColor=white)
+
+**Languages**
+
+![Python](https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=white)
 ![Swift](https://img.shields.io/badge/Swift-F05138?style=flat&logo=swift&logoColor=white)
 ![SwiftUI](https://img.shields.io/badge/SwiftUI-0071E3?style=flat&logo=swift&logoColor=white)
-![Objective‑C](https://img.shields.io/badge/Objective--C-438EFF?style=flat&logo=apple&logoColor=white)
-![Python](https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=white)
-![Ruby](https://img.shields.io/badge/Ruby-CC342D?style=flat&logo=ruby&logoColor=white)
-![Bash](https://img.shields.io/badge/Bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
-![Fastlane](https://img.shields.io/badge/Fastlane-00F200?style=flat&logo=fastlane&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github-actions&logoColor=white)
-![CircleCI](https://img.shields.io/badge/CircleCI-343434?style=flat&logo=circleci&logoColor=white)
-![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=flat&logo=terraform&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)
-![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat&logo=amazonaws&logoColor=white)
-
-<details>
-<summary>Full toolbox</summary>
-
-**Languages & Frameworks**
-
-![Objective‑C](https://img.shields.io/badge/Objective--C-438EFF?style=flat&logo=apple&logoColor=white)
-![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=flat&logo=javascript&logoColor=black)
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white)
-![React Native](https://img.shields.io/badge/React_Native-61DAFB?style=flat&logo=react&logoColor=black)
 ![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat&logo=nodedotjs&logoColor=white)
-![GraphQL](https://img.shields.io/badge/GraphQL-E10098?style=flat&logo=graphql&logoColor=white)
 
-**Apple Ecosystem**
+**CI/CD & DevX**
 
-![macOS](https://img.shields.io/badge/macOS-000000?style=flat&logo=macos&logoColor=white)
-![iOS](https://img.shields.io/badge/iOS-000000?style=flat&logo=apple&logoColor=white)
-![Xcode](https://img.shields.io/badge/Xcode-147EFB?style=flat&logo=xcode&logoColor=white)
-![TestFlight](https://img.shields.io/badge/TestFlight-0D96F6?style=flat&logo=apple&logoColor=white)
-![CocoaPods](https://img.shields.io/badge/CocoaPods-EE3322?style=flat&logo=cocoapods&logoColor=white)
-![SPM](https://img.shields.io/badge/Swift_PM-F05138?style=flat&logo=swift&logoColor=white)
-![XcodeGen](https://img.shields.io/badge/XcodeGen-147EFB?style=flat&logo=xcode&logoColor=white)
+![CircleCI](https://img.shields.io/badge/CircleCI-343434?style=flat&logo=circleci&logoColor=white)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github-actions&logoColor=white)
+![Claude](https://img.shields.io/badge/Claude-D97757?style=flat&logo=claude&logoColor=white)
+![D2](https://img.shields.io/badge/D2-5C6BC0?style=flat&logo=d2&logoColor=white)
 
-**CI/CD & DevOps**
+**Atlassian**
 
-![Bitrise](https://img.shields.io/badge/Bitrise-683D87?style=flat&logo=bitrise&logoColor=white)
-![Danger](https://img.shields.io/badge/Danger-FF3030?style=flat&logo=ruby&logoColor=white)
-![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=flat&logo=ansible&logoColor=white)
-![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat&logo=helm&logoColor=white)
+![Jira](https://img.shields.io/badge/Jira-0052CC?style=flat&logo=jira&logoColor=white)
+![Confluence](https://img.shields.io/badge/Confluence-172B4D?style=flat&logo=confluence&logoColor=white)
+![Forge](https://img.shields.io/badge/Atlassian_Forge-FF5630?style=flat&logo=atlassian&logoColor=white)
 
-**Cloud & Infrastructure**
+**Observability**
 
-![Firebase](https://img.shields.io/badge/Firebase-DD2C00?style=flat&logo=firebase&logoColor=white)
-![CloudKit](https://img.shields.io/badge/CloudKit-0071E3?style=flat&logo=icloud&logoColor=white)
-![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat&logo=cloudflare&logoColor=white)
-![Vercel](https://img.shields.io/badge/Vercel-000000?style=flat&logo=vercel&logoColor=white)
-![Netlify](https://img.shields.io/badge/Netlify-00C7B7?style=flat&logo=netlify&logoColor=white)
-![Nginx](https://img.shields.io/badge/Nginx-009639?style=flat&logo=nginx&logoColor=white)
-![Redis](https://img.shields.io/badge/Redis-DC382D?style=flat&logo=redis&logoColor=white)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat&logo=postgresql&logoColor=white)
-
-**Monitoring & Quality**
-
+![Qlty](https://img.shields.io/badge/Qlty-7C3AED?style=flat&logo=qlty&logoColor=white)
 ![Sentry](https://img.shields.io/badge/Sentry-362D59?style=flat&logo=sentry&logoColor=white)
 ![Datadog](https://img.shields.io/badge/Datadog-632CA6?style=flat&logo=datadog&logoColor=white)
-![SonarQube](https://img.shields.io/badge/SonarQube-4E9BCD?style=flat&logo=sonarqube&logoColor=white)
-![Code Climate](https://img.shields.io/badge/Code_Climate-000000?style=flat&logo=codeclimate&logoColor=white)
-![BrowserStack](https://img.shields.io/badge/BrowserStack-FF6C37?style=flat&logo=browserstack&logoColor=white)
-![Swagger](https://img.shields.io/badge/Swagger-85EA2D?style=flat&logo=swagger&logoColor=black)
-![Postman](https://img.shields.io/badge/Postman-FF6C37?style=flat&logo=postman&logoColor=white)
+![New Relic](https://img.shields.io/badge/New_Relic-1CE783?style=flat&logo=newrelic&logoColor=black)
 
-**Networking & Security**
+<details>
+<summary>Also in the mix</summary>
 
-![Ubiquiti](https://img.shields.io/badge/UniFi-0559C9?style=flat&logo=ubiquiti&logoColor=white)
-![Tailscale](https://img.shields.io/badge/Tailscale-000000?style=flat&logo=tailscale&logoColor=white)
-![WireGuard](https://img.shields.io/badge/WireGuard-88171A?style=flat&logo=wireguard&logoColor=white)
-![Let's Encrypt](https://img.shields.io/badge/Let's_Encrypt-003A70?style=flat&logo=letsencrypt&logoColor=white)
-
-**Project Management**
-
-![Jira](https://img.shields.io/badge/Jira-0052CC?style=flat&logo=jirasoftware&logoColor=white)
-![Confluence](https://img.shields.io/badge/Confluence-172B4D?style=flat&logo=confluence&logoColor=white)
-![Linear](https://img.shields.io/badge/Linear-5E6AD2?style=flat&logo=linear&logoColor=white)
-![Notion](https://img.shields.io/badge/Notion-000000?style=flat&logo=notion&logoColor=white)
-![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat&logo=slack&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
+![Make](https://img.shields.io/badge/Make-6D00CC?style=flat&logo=gnumake&logoColor=white)
 
 </details>
-
-## Featured work
-
-- **[ios-orb][ios-orb]** — CircleCI orb for iOS DevOps.
-- **[danger-pivotal_tracker][danger]** — Danger plugin that links Pivotal
-    Tracker stories to PRs.
-- **[MobileCI][mobileci]** — CircleCI orb experiments for iOS.
-
-[ios-orb]: https://github.com/kevnm67/ios-orb
-[danger]: https://github.com/kevnm67/danger-pivotal_tracker
-[mobileci]: https://github.com/kevnm67/MobileCI

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ infrastructure, and build AI-leveraged developer experience.
 
 - 👥 **Lead DevOps & QA automation** — scaling the teams, pipelines, and
     release processes behind reliable shipping
-- 🏗️ **Architecture & consulting** — infrastructure, platform, and systems
-    design across AWS and Azure
+- 🏗️ **Infra & architecture** — platform and systems design across AWS
+    and Azure
 - 🤖 **AI-leveraged developer experience** — Claude and Claude Code woven
     into CI, review, and automation
 - 🧩 **Atlassian platform** — Jira / Atlassian admin and Forge app

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ infrastructure, and build AI-leveraged developer experience.
 
 ## What I do
 
-- 👥 **Lead DevOps & QA automation** — scaling the teams, pipelines, and
-    release processes behind reliable shipping
+- 👥 **Lead DevOps & QA automation** — the teams, CI/CD pipelines, and
+    release process
 - 🏗️ **Infra & architecture** — platform and systems design across AWS
     and Azure
-- 🤖 **AI-leveraged developer experience** — Claude and Claude Code woven
-    into CI, review, and automation
-- 🧩 **Atlassian platform** — Jira / Atlassian admin and Forge app
+- 🤖 **AI-leveraged developer experience** — Claude and Claude Code in CI,
+    code review, and automation
+- 🧩 **Atlassian platform** — Jira/Atlassian admin and Forge app
     development
+- 📱 **iOS & macOS** — Swift, SwiftUI, and Fastlane; a constant throughout
+    my career, just not the current focus
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ I lead DevOps and QA automation teams, architect cloud + platform
 infrastructure, and build AI-leveraged developer experience.
 
 ![GitHub stats](https://gh-readme-stats-iota-navy.vercel.app/api?username=kevnm67&count_private=true&include_all_commits=true&theme=tokyonight&hide_border=true&show_icons=true)
+![GitHub streak](https://github-readme-streak-stats-five-pi.vercel.app/?user=kevnm67&theme=tokyonight&hide_border=true)
 
 ## What I do
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,18 @@
 Senior DevOps Engineering Manager from Atlanta.
 I build tools that make teams ship faster.
 
-![github stats](https://github-readme-stats-sigma-five.vercel.app/api?username=kevnm67&count_private=true&theme=tokyonight&hide_border=true&show_icons=true)
+|  |  |
+| :--: | :--: |
+| ![GitHub stats](https://github-readme-stats-sigma-five.vercel.app/api?username=kevnm67&count_private=true&theme=tokyonight&hide_border=true&show_icons=true) | ![Top languages](https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=kevnm67&theme=tokyonight&hide_border=true&layout=compact&langs_count=8) |
 
-## What I Do
+## What I do
 
-- 📱 **iOS & macOS apps** — Swift 6, SwiftUI, XcodeGen,
-    CI/CD pipelines
-- 🔧 **DevOps tooling** — CircleCI orbs, Fastlane automation,
-    deployment pipelines
-- 🌐 **Network infrastructure** — UniFi management, VLAN
-    design, security hardening
-- 🤖 **Developer productivity** — AI-assisted workflows,
-    metrics dashboards, automation
+- 📱 **iOS & macOS apps** — Swift 6, SwiftUI, XcodeGen, CI/CD
+- 🔧 **DevOps tooling** — CircleCI orbs, Fastlane, deployment pipelines
+- 🌐 **Network infrastructure** — UniFi, VLAN design, security hardening
+- 🤖 **Developer productivity** — AI-assisted workflows, automation
 
-## Stack
-
-**Languages & Frameworks**
+## Core stack
 
 ![Swift](https://img.shields.io/badge/Swift-F05138?style=flat&logo=swift&logoColor=white)
 ![SwiftUI](https://img.shields.io/badge/SwiftUI-0071E3?style=flat&logo=swift&logoColor=white)
@@ -26,6 +22,19 @@ I build tools that make teams ship faster.
 ![Python](https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=white)
 ![Ruby](https://img.shields.io/badge/Ruby-CC342D?style=flat&logo=ruby&logoColor=white)
 ![Bash](https://img.shields.io/badge/Bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
+![Fastlane](https://img.shields.io/badge/Fastlane-00F200?style=flat&logo=fastlane&logoColor=white)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github-actions&logoColor=white)
+![CircleCI](https://img.shields.io/badge/CircleCI-343434?style=flat&logo=circleci&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=flat&logo=terraform&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat&logo=amazonaws&logoColor=white)
+
+<details>
+<summary>Full toolbox</summary>
+
+**Languages & Frameworks**
+
+![Objective‑C](https://img.shields.io/badge/Objective--C-438EFF?style=flat&logo=apple&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=flat&logo=javascript&logoColor=black)
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white)
 ![React Native](https://img.shields.io/badge/React_Native-61DAFB?style=flat&logo=react&logoColor=black)
@@ -44,19 +53,13 @@ I build tools that make teams ship faster.
 
 **CI/CD & DevOps**
 
-![CircleCI](https://img.shields.io/badge/CircleCI-343434?style=flat&logo=circleci&logoColor=white)
-![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github-actions&logoColor=white)
 ![Bitrise](https://img.shields.io/badge/Bitrise-683D87?style=flat&logo=bitrise&logoColor=white)
-![Fastlane](https://img.shields.io/badge/Fastlane-00F200?style=flat&logo=fastlane&logoColor=white)
 ![Danger](https://img.shields.io/badge/Danger-FF3030?style=flat&logo=ruby&logoColor=white)
-![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=flat&logo=terraform&logoColor=white)
 ![Ansible](https://img.shields.io/badge/Ansible-EE0000?style=flat&logo=ansible&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)
 ![Helm](https://img.shields.io/badge/Helm-0F1689?style=flat&logo=helm&logoColor=white)
 
 **Cloud & Infrastructure**
 
-![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat&logo=amazonaws&logoColor=white)
 ![Firebase](https://img.shields.io/badge/Firebase-DD2C00?style=flat&logo=firebase&logoColor=white)
 ![CloudKit](https://img.shields.io/badge/CloudKit-0071E3?style=flat&logo=icloud&logoColor=white)
 ![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=flat&logo=cloudflare&logoColor=white)
@@ -90,3 +93,16 @@ I build tools that make teams ship faster.
 ![Linear](https://img.shields.io/badge/Linear-5E6AD2?style=flat&logo=linear&logoColor=white)
 ![Notion](https://img.shields.io/badge/Notion-000000?style=flat&logo=notion&logoColor=white)
 ![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat&logo=slack&logoColor=white)
+
+</details>
+
+## Featured work
+
+- **[ios-orb][ios-orb]** — CircleCI orb for iOS DevOps.
+- **[danger-pivotal_tracker][danger]** — Danger plugin that links Pivotal
+    Tracker stories to PRs.
+- **[MobileCI][mobileci]** — CircleCI orb experiments for iOS.
+
+[ios-orb]: https://github.com/kevnm67/ios-orb
+[danger]: https://github.com/kevnm67/danger-pivotal_tracker
+[mobileci]: https://github.com/kevnm67/MobileCI


### PR DESCRIPTION
## Summary

Evolution of the existing profile README (Option A — "Refined Evolution"),
chosen from three proposed directions. Keeps the established voice, theme,
and stats host; fixes the main weakness (badge overload) and adds context.

Per request: **no social/contact links and no marketing fluff** — the
content stays factual.

## Changes

- **Focused Core stack** — replaced the 7-row, ~50-badge wall with a tight
  12-badge core (Swift, SwiftUI, Obj-C, Python, Ruby, Bash, Fastlane,
  GitHub Actions, CircleCI, Terraform, Docker, AWS). The complete set now
  lives in a collapsible **Full toolbox** `<details>` — nothing was lost.
- **Top-languages card** added beside the existing GitHub stats card
  (same tokyonight theme, same self-hosted `github-readme-stats` host).
- **Featured work** section linking `ios-orb`, `danger-pivotal_tracker`,
  and `MobileCI` with one-line context.
- Trimmed the "What I do" copy slightly; kept the original header/voice.

## Verification

- Confirmed both stats endpoints and badge host return `200 image/svg+xml`.
- Checked against the repo's `.markdownlint.yaml` (80-char lines via
  MD013, 4-space indent via MD007): **0 violations** — badge/URL lines and
  the stats table are correctly exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6TR4sz8vWQvX85uW7DXc7)_