### PR TITLE
Tighten What I do copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ infrastructure, and build AI-leveraged developer experience.
 
 ## What I do
 
-- 👥 **Lead DevOps & QA automation teams**
+- 👥 **Lead DevOps & QA automation** — CI/CD, infra, automation, and
+    making developer experience a pleasure 😎
 - 🏗️ **Infra & architecture** — platform and systems design across AWS
     and Azure
 - 🤖 **AI-leveraged developer experience** — Claude and Claude Code in CI,

--- a/README.md
+++ b/README.md
@@ -10,16 +10,14 @@ infrastructure, and build AI-leveraged developer experience.
 
 ## What I do
 
-- 👥 **Lead DevOps & QA automation** — the teams, CI/CD pipelines, and
-    release process
+- 👥 **Lead DevOps & QA automation teams**
 - 🏗️ **Infra & architecture** — platform and systems design across AWS
     and Azure
 - 🤖 **AI-leveraged developer experience** — Claude and Claude Code in CI,
     code review, and automation
 - 🧩 **Atlassian platform** — Jira/Atlassian admin and Forge app
     development
-- 📱 **iOS & macOS** — Swift, SwiftUI, and Fastlane; a constant throughout
-    my career, just not the current focus
+- 📱 **iOS & macOS** — Swift, SwiftUI, and Fastlane
 
 ## Stack
 


### PR DESCRIPTION
Copy-only polish to the What I do bullets (no merge until approved).

- **Bullet 1** — dropped the `teams, CI/CD pipelines, and release process` tricolon (reads AI-generated); now just states the role.
- **iOS bullet** — removed the `a constant throughout my career…` clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)